### PR TITLE
Use ENV variable to use live API

### DIFF
--- a/R/alpaca4R.R
+++ b/R/alpaca4R.R
@@ -1,7 +1,7 @@
 # OUR URL & HEADER VARIABLES SENT IN EACH API REQUEST #
 #===================================================================================================
 #To connect to our paper.account. Live is -> https://api.alpaca.markets
-url <- "https://paper-api.alpaca.markets"
+url <- if(Sys.getenv("APCA-LIVE")) "https://api.alpaca.markets" else "https://paper-api.alpaca.markets"
 
 #To access data API
 url_data <- "https://data.alpaca.markets"


### PR DESCRIPTION
Allows for the `APCA-LIVE` ENV var to change the base URL to live API if set or use test/paper API when not set.