### PR TITLE
Market_Data.R update to ignore adjustment parameter for non-bar API requests

### DIFF
--- a/R/Market_Data.R
+++ b/R/Market_Data.R
@@ -377,9 +377,10 @@ bars_url <- function(symbol, ..., evar = get0("evar", mode = "environment", envi
         timeframe = paste0(multiplier, timeframe)
       )
     ))
-    if (v == 2 && timeframe %in% tqs)
+    if (v == 2 && timeframe %in% tqs) {
       .query$timeframe = NULL
       .query$adjustment = NULL
+    }
     # Build the url
     if (isTRUE(length(.symbol) == 1)) {
       .args <- list(path = .path,

--- a/R/Market_Data.R
+++ b/R/Market_Data.R
@@ -379,6 +379,7 @@ bars_url <- function(symbol, ..., evar = get0("evar", mode = "environment", envi
     ))
     if (v == 2 && timeframe %in% tqs)
       .query$timeframe = NULL
+      .query$adjustment = NULL
     # Build the url
     if (isTRUE(length(.symbol) == 1)) {
       .args <- list(path = .path,

--- a/R/Market_Data.R
+++ b/R/Market_Data.R
@@ -367,7 +367,7 @@ bars_url <- function(symbol, ..., evar = get0("evar", mode = "environment", envi
         end = bounds$to,
         until = bounds$until
       ),
-      . == 2 && timeframe == "ss" ~ list(symbols = .symbol),
+      . == 2 && timeframe == "ss" && length(symbol) > 1 ~ list(symbols = .symbol),
       . == 2 ~ list(
         start = bounds$from %||% bounds$after,
         end = bounds$to %||% bounds$until,

--- a/R/Market_Data.R
+++ b/R/Market_Data.R
@@ -367,7 +367,7 @@ bars_url <- function(symbol, ..., evar = get0("evar", mode = "environment", envi
         end = bounds$to,
         until = bounds$until
       ),
-      . == 2 && timeframe == "ss" && length(symbol) > 1 ~ list(symbols = .symbol),
+      . == 2 && timeframe == "ss" ~ list(symbols = .symbol),
       . == 2 ~ list(
         start = bounds$from %||% bounds$after,
         end = bounds$to %||% bounds$until,


### PR DESCRIPTION
Fixed an issue where the adjustment parameter was being sent in queries where it is not an allowable API parameter.

Please note I uncovered an existing issue where depending on the number of symbols in the query and information type, 'start', 'end', and 'limit' parameters sometimes get constructed in the request when they can't be accepted by the API.

For example, when querying last quote:
"market_data(c('AMD'), v = 2, timeframe = 'lq')" works when there is only one symbol but
"market_data(c('AMD','F'), v = 2, timeframe = 'lq')" does not work when there are multiple symbols. In this case I get the error:
Error: code: 400
message: unexpected parameter(s): start, end, limit

I get the same issue with a snapshot request where it returns the 400 error when there is only one symbol, but that works when there are multiple. I tried a few fixes but nothing seemed to work so figured I'd post it here if you get time to look at it.
Thanks!